### PR TITLE
Refactor tray icon logic and extend test coverage

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -38,39 +38,78 @@ func getRGBA8(img image.Image, x, y int) (r, g, b, a uint8) {
 	return uint8(rr >> 8), uint8(gg >> 8), uint8(bb >> 8), uint8(aa >> 8)
 }
 
-func TestGetIconOriginalAndInvalidName(t *testing.T) {
-	ex, err := os.Executable()
-	if err != nil {
-		t.Fatalf("os.Executable error: %v", err)
+// setupTestIconDir creates tmpDir with assets/icon and Resources/assets/icon containing iconName.png, sets AMM_ICON_DIR and Chdir. Caller must defer os.Chdir(origWd) and os.Unsetenv("AMM_ICON_DIR"). Returns tmpDir.
+func setupTestIconDir(t *testing.T, iconName string) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	assetsDir := filepath.Join(tmpDir, "assets", "icon")
+	resDir := filepath.Join(tmpDir, "Resources", "assets", "icon")
+	iconPathAssets := filepath.Join(assetsDir, iconName+".png")
+	iconPathRes := filepath.Join(resDir, iconName+".png")
+	if err := writeTestPNG(iconPathAssets); err != nil {
+		t.Fatalf("writeTestPNG assets error: %v", err)
 	}
-	dir := filepath.Dir(ex)
+	if err := writeTestPNG(iconPathRes); err != nil {
+		t.Fatalf("writeTestPNG resources error: %v", err)
+	}
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(origWd) })
+	os.Setenv("AMM_ICON_DIR", tmpDir)
+	t.Cleanup(func() { os.Unsetenv("AMM_ICON_DIR") })
+	return tmpDir
+}
 
-	assetsDir := filepath.Join(dir, "..", "assets", "icon")
-	resDir := filepath.Join(dir, "..", "Resources", "assets", "icon")
-
+func TestGetIconOriginalAndInvalidName(t *testing.T) {
+	tmpDir := t.TempDir()
+	assetsDir := filepath.Join(tmpDir, "assets", "icon")
+	resDir := filepath.Join(tmpDir, "Resources", "assets", "icon")
 	mousePathAssets := filepath.Join(assetsDir, "mouse.png")
 	mousePathRes := filepath.Join(resDir, "mouse.png")
-
-	// create both locations to be robust to either branch in getIcon
 	if err := writeTestPNG(mousePathAssets); err != nil {
 		t.Fatalf("writeTestPNG assets error: %v", err)
 	}
 	if err := writeTestPNG(mousePathRes); err != nil {
 		t.Fatalf("writeTestPNG resources error: %v", err)
 	}
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	defer os.Chdir(origWd)
+	os.Setenv("AMM_ICON_DIR", tmpDir)
+	defer os.Unsetenv("AMM_ICON_DIR")
 
-	// call getIcon for valid name, inactive
-	b := getIcon("mouse", false, "")
+	// call getTrayIcon for valid name, inactive (alpha reduced to alphaInactive)
+	b := getTrayIcon("mouse", false, "")
 	if len(b) == 0 {
-		t.Fatalf("getIcon returned empty bytes")
+		t.Fatalf("getTrayIcon returned empty bytes")
 	}
 	img, err := png.Decode(bytes.NewReader(b))
 	if err != nil {
 		t.Fatalf("decode returned bytes error: %v", err)
 	}
+	if bnd := img.Bounds(); bnd.Dx() != 2 || bnd.Dy() != 2 {
+		t.Fatalf("expected 2x2 image (test PNG), got %dx%d", bnd.Dx(), bnd.Dy())
+	}
 	r, g, bl, a := getRGBA8(img, 0, 0)
-	if r != 255 || g != 0 || bl != 0 || a != 255 {
-		t.Fatalf("expected (255,0,0,255) at (0,0), got (%d,%d,%d,%d)", r, g, bl, a)
+	if g != 0 || bl != 0 {
+		t.Fatalf("expected (?,0,0,?) at (0,0), got (%d,%d,%d,%d)", r, g, bl, a)
+	}
+	if r == 0 {
+		t.Fatalf("expected non-zero R at (0,0), got (%d,%d,%d,%d)", r, g, bl, a)
+	}
+	expectedAlpha := uint8(255 * alphaInactive) // 153
+	if a != expectedAlpha {
+		t.Fatalf("expected alpha %d (inactive) at (0,0), got %d", expectedAlpha, a)
 	}
 	// transparent pixel should remain transparent
 	_, _, _, a2 := getRGBA8(img, 0, 1)
@@ -79,48 +118,54 @@ func TestGetIconOriginalAndInvalidName(t *testing.T) {
 	}
 
 	// calling with invalid name must default to mouse -> validate pixel
-	b2 := getIcon("invalid-name", false, "")
+	b2 := getTrayIcon("invalid-name", false, "")
 	img2, err := png.Decode(bytes.NewReader(b2))
 	if err != nil {
 		t.Fatalf("decode invalid-name returned bytes error: %v", err)
 	}
 	r3, _, _, a3 := getRGBA8(img2, 0, 0)
-	if r3 != 255 || a3 != 255 {
-		t.Fatalf("invalid-name did not default to mouse image; got (%d,%d)", r3, a3)
+	expectedAlpha3 := uint8(255 * alphaInactive)
+	if a3 != expectedAlpha3 {
+		t.Fatalf("invalid-name did not default to mouse image (inactive alpha); got a=%d want %d", a3, expectedAlpha3)
+	}
+	if r3 == 0 {
+		t.Fatalf("invalid-name did not default to mouse image; got r=%d", r3)
 	}
 }
 
 func TestGetIconActiveRecolors(t *testing.T) {
-	ex, err := os.Executable()
-	if err != nil {
-		t.Fatalf("os.Executable error: %v", err)
-	}
-	dir := filepath.Dir(ex)
-
-	assetsDir := filepath.Join(dir, "..", "assets", "icon")
-	resDir := filepath.Join(dir, "..", "Resources", "assets", "icon")
-
+	tmpDir := t.TempDir()
+	assetsDir := filepath.Join(tmpDir, "assets", "icon")
+	resDir := filepath.Join(tmpDir, "Resources", "assets", "icon")
 	mousePathAssets := filepath.Join(assetsDir, "mouse.png")
 	mousePathRes := filepath.Join(resDir, "mouse.png")
-
-	// write test PNGs in both locations
 	if err := writeTestPNG(mousePathAssets); err != nil {
 		t.Fatalf("writeTestPNG assets error: %v", err)
 	}
 	if err := writeTestPNG(mousePathRes); err != nil {
 		t.Fatalf("writeTestPNG resources error: %v", err)
 	}
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	defer os.Chdir(origWd)
+	os.Setenv("AMM_ICON_DIR", tmpDir)
+	defer os.Unsetenv("AMM_ICON_DIR")
 
-	// call getIcon with active=true
-	b := getIcon("mouse", true, "")
+	// call getTrayIcon with active=true and color "blue" -> recolor to blue
+	b := getTrayIcon("mouse", true, "blue")
 	if len(b) == 0 {
-		t.Fatalf("getIcon active returned empty bytes")
+		t.Fatalf("getTrayIcon active+blue returned empty bytes")
 	}
 	img, err := png.Decode(bytes.NewReader(b))
 	if err != nil {
 		t.Fatalf("decode active returned bytes error: %v", err)
 	}
-	// non-transparent pixels should be recolored to (30,144,255,255)
+	// non-transparent pixels should be recolored to blue (30,144,255,255)
 	r, g, bl, a := getRGBA8(img, 0, 0)
 	if r != 30 || g != 144 || bl != 255 || a != 255 {
 		t.Fatalf("expected recolored (30,144,255,255) at (0,0), got (%d,%d,%d,%d)", r, g, bl, a)
@@ -129,5 +174,128 @@ func TestGetIconActiveRecolors(t *testing.T) {
 	_, _, _, a2 := getRGBA8(img, 0, 1)
 	if a2 != 0 {
 		t.Fatalf("expected alpha 0 at (0,1) after active recolor, got %d", a2)
+	}
+}
+
+func TestGetTrayIconActiveNoColor(t *testing.T) {
+	setupTestIconDir(t, "mouse")
+
+	b := getTrayIcon("mouse", true, "")
+	if len(b) == 0 {
+		t.Fatalf("getTrayIcon returned empty bytes")
+	}
+	img, err := png.Decode(bytes.NewReader(b))
+	if err != nil {
+		t.Fatalf("decode returned bytes error: %v", err)
+	}
+	if bnd := img.Bounds(); bnd.Dx() != 2 || bnd.Dy() != 2 {
+		t.Fatalf("expected 2x2 image (test PNG), got %dx%d", bnd.Dx(), bnd.Dy())
+	}
+	r, g, bl, a := getRGBA8(img, 0, 0)
+	if r != 255 || g != 0 || bl != 0 || a != 255 {
+		t.Fatalf("expected (255,0,0,255) at (0,0), got (%d,%d,%d,%d)", r, g, bl, a)
+	}
+	_, _, _, a2 := getRGBA8(img, 0, 1)
+	if a2 != 0 {
+		t.Fatalf("expected alpha 0 at (0,1), got %d", a2)
+	}
+
+	// result must match loadIconFile (original bytes)
+	orig := getMenuIcon("mouse")
+	if !bytes.Equal(b, orig) {
+		t.Fatalf("getTrayIcon(active, no color) should return same bytes as loadIconFile")
+	}
+}
+
+func TestGetTrayIconColorsRedWhite(t *testing.T) {
+	setupTestIconDir(t, "mouse")
+
+	t.Run("red", func(t *testing.T) {
+		b := getTrayIcon("mouse", true, "red")
+		if len(b) == 0 {
+			t.Fatalf("getTrayIcon red returned empty bytes")
+		}
+		img, err := png.Decode(bytes.NewReader(b))
+		if err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		r, g, bl, a := getRGBA8(img, 0, 0)
+		if r != 255 || g != 0 || bl != 0 || a != 255 {
+			t.Fatalf("expected colorRed (255,0,0,255) at (0,0), got (%d,%d,%d,%d)", r, g, bl, a)
+		}
+		_, _, _, a2 := getRGBA8(img, 0, 1)
+		if a2 != 0 {
+			t.Fatalf("expected alpha 0 at (0,1), got %d", a2)
+		}
+	})
+
+	t.Run("white", func(t *testing.T) {
+		b := getTrayIcon("mouse", true, "white")
+		if len(b) == 0 {
+			t.Fatalf("getTrayIcon white returned empty bytes")
+		}
+		img, err := png.Decode(bytes.NewReader(b))
+		if err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		r, g, bl, a := getRGBA8(img, 0, 0)
+		if r != 255 || g != 255 || bl != 255 || a != 255 {
+			t.Fatalf("expected colorWhite (255,255,255,255) at (0,0), got (%d,%d,%d,%d)", r, g, bl, a)
+		}
+		_, _, _, a2 := getRGBA8(img, 0, 1)
+		if a2 != 0 {
+			t.Fatalf("expected alpha 0 at (0,1), got %d", a2)
+		}
+	})
+}
+
+func TestGetMenuIcon(t *testing.T) {
+	setupTestIconDir(t, "mouse")
+
+	menuIcon := getMenuIcon("mouse")
+	if len(menuIcon) == 0 {
+		t.Fatalf("getMenuIcon returned empty bytes")
+	}
+	img, err := png.Decode(bytes.NewReader(menuIcon))
+	if err != nil {
+		t.Fatalf("decode getMenuIcon bytes: %v", err)
+	}
+	if bnd := img.Bounds(); bnd.Dx() != 2 || bnd.Dy() != 2 {
+		t.Fatalf("expected 2x2 image, got %dx%d", bnd.Dx(), bnd.Dy())
+	}
+	// getMenuIcon should return same as loadIconFile -> same as getTrayIcon(active, no color)
+	orig := getTrayIcon("mouse", true, "")
+	if !bytes.Equal(menuIcon, orig) {
+		t.Fatalf("getMenuIcon should return same bytes as getTrayIcon(active, no color)")
+	}
+}
+
+func TestLoadIconFilePanicWhenNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(origWd) })
+	os.Setenv("AMM_ICON_DIR", tmpDir)
+	t.Cleanup(func() { os.Unsetenv("AMM_ICON_DIR") })
+	// tmpDir has no assets/icon/mouse.png, so loadIconFile (via getTrayIcon) must panic
+	var panicked interface{}
+	func() {
+		defer func() { panicked = recover() }()
+		getTrayIcon("mouse", true, "")
+	}()
+	if panicked == nil {
+		t.Fatalf("expected panic when icon file not found")
+	}
+	errMsg, ok := panicked.(string)
+	if !ok {
+		t.Fatalf("expected string panic message, got %T: %v", panicked, panicked)
+	}
+	if errMsg != "Failed to load icon: mouse.png" {
+		t.Fatalf("expected panic \"Failed to load icon: mouse.png\", got %q", errMsg)
 	}
 }


### PR DESCRIPTION
Hello @Resousse,

Additional info is here https://github.com/prashantgupta24/automatic-mouse-mover/pull/66

I added dark/light mode support for icons, made an additional "System" option for icon colors, and added Alpha transparency for inactive icons. If you do not use custom colors, then everything should be in the macos style and the inactive icon will be darkened, but the active one in the menu bar style, depending on the dark/light mode and wallpaper.

<img width="266" height="259" alt="SCR-20260129-mtag" src="https://github.com/user-attachments/assets/eb037980-b6e2-42de-894b-7804ee8398a4" />
<img width="294" height="235" alt="SCR-20260129-mubo" src="https://github.com/user-attachments/assets/581ed919-8808-496c-bc5e-e32a9408e1c5" />
<img width="294" height="235" alt="SCR-20260129-mtys" src="https://github.com/user-attachments/assets/305c1462-bb3f-460b-95f6-9f3cb618e0f5" />


| Custom color active | Default system active | Inactive |
|---|---|---|
| <img width="236" height="158" alt="SCR-20260129-mufe" src="https://github.com/user-attachments/assets/9ddf33eb-2721-42e1-bcbf-ec238f87e0cf" /> | <img width="245" height="124" alt="SCR-20260129-muec" src="https://github.com/user-attachments/assets/641232c2-0945-46b4-b312-69f436f92822" /> | <img width="284" height="145" alt="SCR-20260129-mucz" src="https://github.com/user-attachments/assets/56bc3a08-ce25-4a23-8e48-1f977e1d72a6" /> |
| <img width="249" height="142" alt="SCR-20260129-mukf" src="https://github.com/user-attachments/assets/8dd1e6ca-a39d-4a99-8b30-56f8a3f3efb7" /> | <img width="234" height="126" alt="SCR-20260129-mujf" src="https://github.com/user-attachments/assets/9fb4f691-8b70-4335-9f3f-4c84099049c6" /> | <img width="253" height="165" alt="SCR-20260129-muic" src="https://github.com/user-attachments/assets/d4db0483-b445-420f-b975-8c8f3e8ae5a2" />
